### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/html/Ant-TaylorDome.Steig.2000.Rmd
+++ b/html/Ant-TaylorDome.Steig.2000.Rmd
@@ -65,7 +65,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://doi.org/10.17911/S9H59X
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.17911/S9H59X
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>

--- a/html/Ant-TaylorDome.Steig.2000.html
+++ b/html/Ant-TaylorDome.Steig.2000.html
@@ -2695,7 +2695,7 @@ window.FlexDashboardComponents.push({
 <p style="margin-left: 0px">
 <strong>archiveType: </strong>glacier ice
 <p style="margin-left: 0px">
-<strong>originalDataURL: </strong><a href="http://doi.org/10.17911/S9H59X" class="uri">http://doi.org/10.17911/S9H59X</a>
+<strong>originalDataURL: </strong><a href="https://doi.org/10.17911/S9H59X" class="uri">https://doi.org/10.17911/S9H59X</a>
 <p style="margin-left: 0px">
 <strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px">
@@ -2863,7 +2863,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://doi.org/10.17911/S9H59X
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.17911/S9H59X
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>

--- a/html/Ant-US-ITASE-2000-1.Steig.2013.Rmd
+++ b/html/Ant-US-ITASE-2000-1.Steig.2013.Rmd
@@ -65,7 +65,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>

--- a/html/Ant-US-ITASE-2000-1.Steig.2013.html
+++ b/html/Ant-US-ITASE-2000-1.Steig.2013.html
@@ -2695,7 +2695,7 @@ window.FlexDashboardComponents.push({
 <p style="margin-left: 0px">
 <strong>archiveType: </strong>glacier ice
 <p style="margin-left: 0px">
-<strong>originalDataURL: </strong><a href="http://dx.doi.org/10.7265/N5QJ7F8B" class="uri">http://dx.doi.org/10.7265/N5QJ7F8B</a>
+<strong>originalDataURL: </strong><a href="https://doi.org/10.7265/N5QJ7F8B" class="uri">https://doi.org/10.7265/N5QJ7F8B</a>
 <p style="margin-left: 0px">
 <strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px">
@@ -2879,7 +2879,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>

--- a/html/Ant-US-ITASE-2002-4.Steig.2013.Rmd
+++ b/html/Ant-US-ITASE-2002-4.Steig.2013.Rmd
@@ -65,7 +65,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>

--- a/html/Ant-US-ITASE-2002-4.Steig.2013.html
+++ b/html/Ant-US-ITASE-2002-4.Steig.2013.html
@@ -2695,7 +2695,7 @@ window.FlexDashboardComponents.push({
 <p style="margin-left: 0px">
 <strong>archiveType: </strong>glacier ice
 <p style="margin-left: 0px">
-<strong>originalDataURL: </strong><a href="http://dx.doi.org/10.7265/N5QJ7F8B" class="uri">http://dx.doi.org/10.7265/N5QJ7F8B</a>
+<strong>originalDataURL: </strong><a href="https://doi.org/10.7265/N5QJ7F8B" class="uri">https://doi.org/10.7265/N5QJ7F8B</a>
 <p style="margin-left: 0px">
 <strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px">
@@ -2879,7 +2879,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>

--- a/html/Ant-WDC05A.Steig.2013.Rmd
+++ b/html/Ant-WDC05A.Steig.2013.Rmd
@@ -65,7 +65,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>JWW, EJS
 </details>

--- a/html/Ant-WDC05A.Steig.2013.html
+++ b/html/Ant-WDC05A.Steig.2013.html
@@ -2695,7 +2695,7 @@ window.FlexDashboardComponents.push({
 <p style="margin-left: 0px">
 <strong>archiveType: </strong>glacier ice
 <p style="margin-left: 0px">
-<strong>originalDataURL: </strong><a href="http://dx.doi.org/10.7265/N5QJ7F8B" class="uri">http://dx.doi.org/10.7265/N5QJ7F8B</a>
+<strong>originalDataURL: </strong><a href="https://doi.org/10.7265/N5QJ7F8B" class="uri">https://doi.org/10.7265/N5QJ7F8B</a>
 <p style="margin-left: 0px">
 <strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px">
@@ -2863,7 +2863,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>JWW, EJS
 </details>

--- a/html/Ant-WDC06A.Steig.2013.Rmd
+++ b/html/Ant-WDC06A.Steig.2013.Rmd
@@ -65,7 +65,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>

--- a/html/Ant-WDC06A.Steig.2013.html
+++ b/html/Ant-WDC06A.Steig.2013.html
@@ -2695,7 +2695,7 @@ window.FlexDashboardComponents.push({
 <p style="margin-left: 0px">
 <strong>archiveType: </strong>glacier ice
 <p style="margin-left: 0px">
-<strong>originalDataURL: </strong><a href="http://dx.doi.org/10.7265/N5QJ7F8B" class="uri">http://dx.doi.org/10.7265/N5QJ7F8B</a>
+<strong>originalDataURL: </strong><a href="https://doi.org/10.7265/N5QJ7F8B" class="uri">https://doi.org/10.7265/N5QJ7F8B</a>
 <p style="margin-left: 0px">
 <strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px">
@@ -2907,7 +2907,7 @@ Metadata {.sidebar}
 <details open style="margin-left: 0px">
 <summary>root</summary>
 <p style="margin-left: 0px"><strong>archiveType: </strong>glacier ice
-<p style="margin-left: 0px"><strong>originalDataURL: </strong>http://dx.doi.org/10.7265/N5QJ7F8B
+<p style="margin-left: 0px"><strong>originalDataURL: </strong>https://doi.org/10.7265/N5QJ7F8B
 <p style="margin-left: 0px"><strong>lipdVersion: </strong>1.3
 <p style="margin-left: 0px"><strong>dataContributor: </strong>EJS
 </details>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!